### PR TITLE
Add support for kondo-powered textDocument/references

### DIFF
--- a/src/sparkling/handlers/general.clj
+++ b/src/sparkling/handlers/general.clj
@@ -38,6 +38,7 @@
 
     :definitionProvider true
     :documentSymbolProvider true
+    :referencesProvider true
 
     :textDocumentSync {:openClose true
                        :didSave true

--- a/src/sparkling/handlers/text_document.clj
+++ b/src/sparkling/handlers/text_document.clj
@@ -8,6 +8,7 @@
             [sparkling.spec.util :refer [validate]]
             [sparkling.tools.completion :refer [suggest-complete]]
             [sparkling.tools.definition :refer [find-definition]]
+            [sparkling.tools.references :refer [find-references]]
             [sparkling.tools.edit :as edit]
             [sparkling.tools.fix :as fix]
             [sparkling.tools.highlight :as highlight]))
@@ -159,3 +160,23 @@
                                  ; TODO :location ?
                                  {:name symbol-name
                                   :kind symbol-kind})))))))))
+
+
+; ======= references ======================================
+
+(defhandler :textDocument/references [{{:keys [character line]} :position,
+                                       {uri :uri} :textDocument}]
+  (p/let [doc (doc-state-of uri)
+          locations (find-references {:document-text doc
+                                      :document-ns (path/->ns uri)
+                                      :uri uri
+                                      :character character
+                                      :line line
+                                      :sparkling/context {:uri uri}})]
+
+    (->> locations
+         (map (fn [{:keys [uri col line]}]
+                (let [start {:line line :character col}]
+                  {:uri uri
+                   :range {:start start
+                           :end start}}))))))

--- a/src/sparkling/static/kondo.clj
+++ b/src/sparkling/static/kondo.clj
@@ -1,5 +1,6 @@
 (ns sparkling.static.kondo
-  (:require [clojure.java.shell :refer [sh]]
+  (:require [clojure.java.io :as io]
+            [clojure.java.shell :refer [sh]]
             [promesa.core :as p]
             [sparkling.builders.util :refer [parse-edn]]))
 
@@ -44,3 +45,17 @@
 
 (defn analyze-string [s]
   (p/future (analyze-string-sync s)))
+
+(defn resolve-uri
+  "Expects config to be the resolved value of *project-config*"
+  [config filename]
+  (when-let [path (or (when (.isAbsolute (io/file filename))
+                        filename)
+
+                      (let [from-root (io/file (:root-path config)
+                                               filename)]
+                        (when (.exists from-root)
+                          (.getAbsolutePath from-root)))
+
+                      filename)]
+    (str "file://" path)))

--- a/src/sparkling/tools/definition.clj
+++ b/src/sparkling/tools/definition.clj
@@ -13,7 +13,6 @@
   (p/let [config *project-config*
           {:keys [match]} (extract-symbol-input
                             document-text character line)
-          _ (println "match= " match)
           results (static-apropos (assoc ctx :root-path (:root-path config))
                                   match)]
     (->> results

--- a/src/sparkling/tools/references.clj
+++ b/src/sparkling/tools/references.clj
@@ -1,0 +1,42 @@
+(ns sparkling.tools.references
+  (:require [promesa.core :as p]
+            [sparkling.config :refer [*project-config*]]
+            [sparkling.static :refer [*kondo-project-path*]]
+            [sparkling.static.kondo :as kondo]
+            [sparkling.tools.definition :refer [kondo-definitions
+                                                kondo->location]]
+            [sparkling.util.promise :as promise]))
+
+(defn- definitions->symbols [defs]
+  (->> defs
+       (map (fn [d]
+              (symbol (name (:ns d))
+                      (name (:name d)))))
+       (into #{})))
+
+(defn- xf-references-to [ctx config defs]
+  (comp
+    (filter (fn [usage]
+              (let [s (symbol (name (:to usage))
+                              (name (:name usage)))]
+                (contains? defs s))))
+    (map (partial kondo->location ctx config))))
+
+(defn- find-references-kondo [{:keys [document-text] :as ctx}]
+  (p/plet [config *project-config*
+           defs (-> (promise/with-timing "kondo-definitions"
+                      (kondo-definitions ctx))
+                    (p/then definitions->symbols))
+           local-analysis (kondo/analyze-string document-text)
+           project *kondo-project-path*]
+    (->> (concat (:var-usages project)
+                 (:var-usages local-analysis))
+         (transduce (xf-references-to ctx config defs) conj [])
+         distinct)))
+
+
+(def ^{:doc "Returns a promise that resolves to a sequence of locations,
+             with keys :uri, :line, :col"}
+  find-references
+  (promise/fallback
+    find-references-kondo))

--- a/src/sparkling/tools/util.clj
+++ b/src/sparkling/tools/util.clj
@@ -35,9 +35,12 @@
                                                    (subs full-line index (inc index)))
                                (reduced (inc index))))
                            character
-                           (range character 0 -1))
-        text-line (subs full-line identifier-start)
-        [_ match] (re-find regex-identifier-head text-line)]
-    {:match match
-     :full-line full-line
-     :text-line text-line}))
+                           (range character -1 -1)) ; down to and including 0
+        text-line (when identifier-start
+                    (subs full-line identifier-start))
+        [_ match] (when text-line
+                    (re-find regex-identifier-head text-line))]
+    (when match
+      {:match match
+       :full-line full-line
+       :text-line text-line})))


### PR DESCRIPTION
This also improves some stability of and removes dups from the find-definitions tool.